### PR TITLE
BAU/redis: Updating the way we handle redis connection env.

### DIFF
--- a/src/main/java/uk/gov/di/ipv/core/back/config/RedisConfig.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/config/RedisConfig.java
@@ -19,10 +19,15 @@ public class RedisConfig {
 
     @Bean("redis-client")
     Jedis jedisClient() {
-        if (redisEndpoint.contains("localhost")) {
+        if (!redisEndpoint.contains("cfenv")) {
             log.info("Using local redis session");
             var split = redisEndpoint.split(":");
-            return new Jedis(split[0], Integer.parseInt(split[1]));
+
+            if (split.length == 2) {
+                return new Jedis(split[0], Integer.parseInt(split[1]));
+            }
+
+            return new Jedis(redisEndpoint, 6379);
         }
 
         // If not using localhost, use cf env to grab the VCAP service


### PR DESCRIPTION
## Whats changed

- If the redis connection endpoint is cfenv, then use the PaaS VCAP credentials,
  otherwise, use the provided value.