### PR TITLE
BAU: Evidence rework

### DIFF
--- a/src/main/java/uk/gov/di/ipv/core/back/restapi/controller/IpvController.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/restapi/controller/IpvController.java
@@ -81,7 +81,7 @@ public class IpvController {
     }
 
     @PostMapping("/{session-id}/add-evidence")
-    public Mono<ResponseEntity<SessionDataDto>> addEvidence(@PathVariable("session-id") UUID sessionId, @RequestBody EvidenceDto evidenceDto) {
+    public Mono<ResponseEntity<EvidenceDto>> addEvidence(@PathVariable("session-id") UUID sessionId, @RequestBody EvidenceDto evidenceDto) {
         var maybeSessionData = sessionService.getSession(sessionId);
 
         if (maybeSessionData.isEmpty()) {

--- a/src/main/java/uk/gov/di/ipv/core/back/restapi/dto/EvidenceDto.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/restapi/dto/EvidenceDto.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.back.restapi.dto;
 import lombok.Data;
 import uk.gov.di.ipv.core.back.domain.data.BundleScores;
 import uk.gov.di.ipv.core.back.domain.data.EvidenceType;
+import uk.gov.di.ipv.core.back.domain.data.IdentityEvidence;
 
 import java.util.UUID;
 
@@ -12,4 +13,13 @@ public class EvidenceDto {
     private EvidenceType type;
     private Object evidenceData;
     private BundleScores bundleScores;
+
+    public static EvidenceDto toDto(IdentityEvidence identityEvidence) {
+        var dto = new EvidenceDto();
+        dto.setType(identityEvidence.getType());
+        dto.setEvidenceId(identityEvidence.getUuid());
+        dto.setEvidenceData(identityEvidence.getEvidenceData());
+
+        return dto;
+    }
 }

--- a/src/main/java/uk/gov/di/ipv/core/back/service/EvidenceService.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/service/EvidenceService.java
@@ -3,9 +3,8 @@ package uk.gov.di.ipv.core.back.service;
 import reactor.core.publisher.Mono;
 import uk.gov.di.ipv.core.back.domain.SessionData;
 import uk.gov.di.ipv.core.back.restapi.dto.EvidenceDto;
-import uk.gov.di.ipv.core.back.restapi.dto.SessionDataDto;
 
 public interface EvidenceService {
 
-    Mono<SessionDataDto> addEvidence(SessionData sessionData, EvidenceDto evidenceDto);
+    Mono<EvidenceDto> addEvidence(SessionData sessionData, EvidenceDto evidenceDto);
 }

--- a/src/main/java/uk/gov/di/ipv/core/back/service/EvidenceService.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/service/EvidenceService.java
@@ -2,9 +2,12 @@ package uk.gov.di.ipv.core.back.service;
 
 import reactor.core.publisher.Mono;
 import uk.gov.di.ipv.core.back.domain.SessionData;
+import uk.gov.di.ipv.core.back.domain.data.IdentityEvidence;
 import uk.gov.di.ipv.core.back.restapi.dto.EvidenceDto;
 
 public interface EvidenceService {
 
     Mono<EvidenceDto> addEvidence(SessionData sessionData, EvidenceDto evidenceDto);
+
+    Mono<Void> deleteEvidence(SessionData sessionData, IdentityEvidence identityEvidence);
 }

--- a/src/main/java/uk/gov/di/ipv/core/back/service/impl/EvidenceServiceImpl.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/service/impl/EvidenceServiceImpl.java
@@ -34,7 +34,7 @@ public class EvidenceServiceImpl implements EvidenceService {
     }
 
     @Override
-    public Mono<SessionDataDto> addEvidence(SessionData sessionData, EvidenceDto evidenceDto) {
+    public Mono<EvidenceDto> addEvidence(SessionData sessionData, EvidenceDto evidenceDto) {
         var identityEvidence = IdentityEvidence.fromDto(evidenceDto);
 
         log.info("Adding new evidence for session {}", sessionData.getSessionId());
@@ -57,8 +57,9 @@ public class EvidenceServiceImpl implements EvidenceService {
         log.info("Posting identity verification bundle to GPG45 for session {}", sessionData.getSessionId());
         var verificationBundle = new VerificationBundleDto(sessionData.getIdentityVerificationBundle());
         var calculateResponseDtoMono = gpg45Service.calculate(verificationBundle);
-
-        return calculateResponseDtoMono.flatMap(gpg45Response -> saveAndReturnSessionDto(gpg45Response, sessionData));
+        return calculateResponseDtoMono
+            .flatMap(gpg45Response -> saveAndReturnSessionDto(gpg45Response, sessionData))
+            .map(_sessionDataDto -> EvidenceDto.toDto(identityEvidence));
     }
 
     private Mono<SessionDataDto> saveAndReturnSessionDto(CalculateResponseDto gpg45Response, SessionData sessionData) {

--- a/src/main/java/uk/gov/di/ipv/core/back/service/impl/EvidenceServiceImpl.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/service/impl/EvidenceServiceImpl.java
@@ -62,6 +62,17 @@ public class EvidenceServiceImpl implements EvidenceService {
             .map(_sessionDataDto -> EvidenceDto.toDto(identityEvidence));
     }
 
+    @Override
+    public Mono<Void> deleteEvidence(SessionData sessionData, IdentityEvidence identityEvidence) {
+        sessionData.getIdentityVerificationBundle().getIdentityEvidence().remove(identityEvidence);
+
+        var verificationBundle = new VerificationBundleDto(sessionData.getIdentityVerificationBundle());
+        var calculateResponseDtoMono = gpg45Service.calculate(verificationBundle);
+        return calculateResponseDtoMono
+            .flatMap(gpg45Response -> saveAndReturnSessionDto(gpg45Response, sessionData))
+            .then();
+    }
+
     private Mono<SessionDataDto> saveAndReturnSessionDto(CalculateResponseDto gpg45Response, SessionData sessionData) {
         var bundle = gpg45Response.getIdentityVerificationBundle();
         var profile = gpg45Response.getMatchedIdentityProfile();


### PR DESCRIPTION
## Proposed changes

### What changed

- Returning evidence dto instead of the whole of session data object when adding evidence.
- Adding a `/ipv/{session-id}/evidence/{evidence-id}/delete` endpoint to delete the evidence.
- Created a method in evidence service to delete the evidence and recalculate.
- Retrieving session data with `/ipv/{session-id}/session` endpoint.
- Added some logging.

### Why did it change

This will reduce the amount of processing required on the core-front side, and allows a way to delete evidence and paves the way for editing evidence.

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed