### PR TITLE
BAU: Adding in the driving license evidence type.

### DIFF
--- a/src/main/java/uk/gov/di/ipv/core/back/domain/data/EvidenceType.java
+++ b/src/main/java/uk/gov/di/ipv/core/back/domain/data/EvidenceType.java
@@ -2,5 +2,6 @@ package uk.gov.di.ipv.core.back.domain.data;
 
 public enum EvidenceType {
     UK_PASSPORT,
-    ATP_GENERIC_DATA;
+    ATP_GENERIC_DATA,
+    DRIVING_LICENCE;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Adding driving license type as that will come to use soon?

### Why did it change

- Right now, the atp playbox has this as a type, this means that if its being used, the core-back will throw a 400 error as its not defined.

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
